### PR TITLE
ECEF fields require integer parsing of twos compliment numbers.

### DIFF
--- a/RTCM3.py
+++ b/RTCM3.py
@@ -88,6 +88,18 @@ def bitValue(bitArray,Start,Length):
         s +=bitArray[i]
     return(int(s,2))
 
+def bitValueSigned(bitArray,Start,Length):
+#    print Start,Length
+    s = ""
+    for i in range (Start,Start+Length):
+        s +=bitArray[i]
+    
+    if bitArray[Start] == '0':
+        return(int(s,2))
+    else:
+        # two's complement
+        return(-(((int(s,2) ^ (0x3fffffffff)) + 1)))
+
 #(**********************************************************************
 # * Compute the CRC24 checksum using a lookup table method.
 # *
@@ -161,7 +173,7 @@ class RTCM3:
                     field["value"]= bitValue(bitArray,current_bit,field["bitlength"])
                     current_bit+=field["bitlength"]
                 elif field["type"] == "INT" :
-                    field["value"]= bitValue(bitArray,current_bit,field["bitlength"])
+                    field["value"]= bitValueSigned(bitArray,current_bit,field["bitlength"])
                     current_bit+=field["bitlength"]
                 elif field["type"] == "REPEAT" :
                     field["value"]= bitValue(bitArray,current_bit,field["bitlength"])

--- a/RTCM3.py
+++ b/RTCM3.py
@@ -98,7 +98,7 @@ def bitValueSigned(bitArray,Start,Length):
         return(int(s,2))
     else:
         # two's complement
-        return(-(((int(s,2) ^ (0x3fffffffff)) + 1)))
+        return(-(((int(s,2) ^ (2**Length-1)) + 1)))
 
 #(**********************************************************************
 # * Compute the CRC24 checksum using a lookup table method.


### PR DESCRIPTION
Integer parsing did not properly handle negative numbers, thus ECEF values decoded from message types 1005 and 1006 were incorrect.  This patch adds the proper parsing of signed integer values.  RTCM integer fields are stored in big-ending, twos-complement notation.  To parse them, if the MSB is 1, then we need to XOR all the bits, add 1, and then add the negative sign.